### PR TITLE
PC-148: Inheritance/onset as always-entereable patient summary fields

### DIFF
--- a/ui/src/main/resources/PhenoTips/Consents.xml
+++ b/ui/src/main/resources/PhenoTips/Consents.xml
@@ -513,7 +513,6 @@ phenomecentral.consent.matching=This patient is matchable through the Matchmaker
         <value>org.phenotips.patientSheet.field.consanguinity</value>
         <value>org.phenotips.patientSheet.field.miscarriages</value>
         <value>org.phenotips.patientSheet.field.affectedRelatives</value>
-        <value>org.phenotips.patientSheet.field.global_mode_of_inheritance</value>
         <value>org.phenotips.patientSheet.field.pedigree</value>
         <value>org.phenotips.patientSheet.field.multipleGestation</value>
         <value>org.phenotips.patientSheet.field.gestation</value>
@@ -524,7 +523,6 @@ phenomecentral.consent.matching=This patient is matchable through the Matchmaker
         <value>org.phenotips.patientSheet.field.prenatal_development</value>
         <value>org.phenotips.patientSheet.field.medical_history</value>
         <value>org.phenotips.patientSheet.field.allergies</value>
-        <value>org.phenotips.patientSheet.field.global_age_of_onset</value>
         <value>org.phenotips.patientSheet.field.reports_history</value>
       </fields>
     </property>

--- a/ui/src/main/resources/PhenoTips/UIX_Field__global_age_of_onset.xml
+++ b/ui/src/main/resources/PhenoTips/UIX_Field__global_age_of_onset.xml
@@ -115,7 +115,7 @@
 {{/velocity}}</content>
     </property>
     <property>
-      <extensionPointId>org.phenotips.patientSheet.section.medical-history</extensionPointId>
+      <extensionPointId>org.phenotips.patientSheet.section.patient-info</extensionPointId>
     </property>
     <property>
       <name>org.phenotips.patientSheet.field.global_age_of_onset</name>
@@ -123,7 +123,7 @@
     <property>
       <parameters>title=$services.localization.render('phenotips.UIXField.globalAgeOfOnset')
 enabled=true
-order=3
+order=10
 required=
 fields=global_age_of_onset</parameters>
     </property>

--- a/ui/src/main/resources/PhenoTips/UIX_Field__global_age_of_onset.xml
+++ b/ui/src/main/resources/PhenoTips/UIX_Field__global_age_of_onset.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+-->
+
+<xwikidoc version="1.1">
+  <web>PhenoTips</web>
+  <name>UIX_Field__global_age_of_onset</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1401822202000</creationDate>
+  <parent>PhenoTips.PatientSheet</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1401822202000</date>
+  <contentUpdateDate>1401822202000</contentUpdateDate>
+  <version>1.1</version>
+  <title>$services.localization.render('phenotips.UIXField.globalAgeOfOnset')</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content/>
+  <object>
+    <name>PhenoTips.UIX_Field__global_age_of_onset</name>
+    <number>0</number>
+    <className>XWiki.UIExtensionClass</className>
+    <guid>f477f684-d0b4-4eb8-ad38-b47d47f3c7bd</guid>
+    <class>
+      <name>XWiki.UIExtensionClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <content>
+        <disabled>0</disabled>
+        <name>content</name>
+        <number>3</number>
+        <prettyName>Extension Content</prettyName>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </content>
+      <extensionPointId>
+        <disabled>0</disabled>
+        <name>extensionPointId</name>
+        <number>1</number>
+        <prettyName>Extension Point ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </extensionPointId>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>2</number>
+        <prettyName>Extension ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parameters>
+        <disabled>0</disabled>
+        <name>parameters</name>
+        <number>4</number>
+        <prettyName>Extension Parameters</prettyName>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </parameters>
+      <scope>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>scope</name>
+        <number>5</number>
+        <prettyName>Extension Scope</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>wiki=Current Wiki|user=Current User|global=Global</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </scope>
+    </class>
+    <property>
+      <content>{{include reference="PhenoTips.PatientSheetMacros" /}}
+
+{{velocity}}
+#__displayIfNotEmpty('global_age_of_onset')
+{{/velocity}}</content>
+    </property>
+    <property>
+      <extensionPointId>org.phenotips.patientSheet.section.medical-history</extensionPointId>
+    </property>
+    <property>
+      <name>org.phenotips.patientSheet.field.global_age_of_onset</name>
+    </property>
+    <property>
+      <parameters>title=$services.localization.render('phenotips.UIXField.globalAgeOfOnset')
+enabled=true
+order=3
+required=
+fields=global_age_of_onset</parameters>
+    </property>
+    <property>
+      <scope>wiki</scope>
+    </property>
+  </object>
+</xwikidoc>

--- a/ui/src/main/resources/PhenoTips/UIX_Field__global_mode_of_inheritance.xml
+++ b/ui/src/main/resources/PhenoTips/UIX_Field__global_mode_of_inheritance.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+-->
+
+<xwikidoc version="1.1">
+  <web>PhenoTips</web>
+  <name>UIX_Field__global_mode_of_inheritance</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1401822218000</creationDate>
+  <parent>PhenoTips.PatientSheet</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1401822218000</date>
+  <contentUpdateDate>1401822218000</contentUpdateDate>
+  <version>1.1</version>
+  <title>$services.localization.render('phenotips.UIXField.globalModeOfInheritance')</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content/>
+  <object>
+    <name>PhenoTips.UIX_Field__global_mode_of_inheritance</name>
+    <number>0</number>
+    <className>XWiki.UIExtensionClass</className>
+    <guid>8b63fae8-caef-4cd3-935d-e079253eb269</guid>
+    <class>
+      <name>XWiki.UIExtensionClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <content>
+        <disabled>0</disabled>
+        <name>content</name>
+        <number>3</number>
+        <prettyName>Extension Content</prettyName>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </content>
+      <extensionPointId>
+        <disabled>0</disabled>
+        <name>extensionPointId</name>
+        <number>1</number>
+        <prettyName>Extension Point ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </extensionPointId>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>2</number>
+        <prettyName>Extension ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parameters>
+        <disabled>0</disabled>
+        <name>parameters</name>
+        <number>4</number>
+        <prettyName>Extension Parameters</prettyName>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </parameters>
+      <scope>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>scope</name>
+        <number>5</number>
+        <prettyName>Extension Scope</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>wiki=Current Wiki|user=Current User|global=Global</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </scope>
+    </class>
+    <property>
+      <content>{{include reference="PhenoTips.PatientSheetMacros" /}}
+
+{{velocity}}
+#__displayIfNotEmpty('global_mode_of_inheritance')
+{{/velocity}}</content>
+    </property>
+    <property>
+      <extensionPointId>org.phenotips.patientSheet.section.family-info</extensionPointId>
+    </property>
+    <property>
+      <name>org.phenotips.patientSheet.field.global_mode_of_inheritance</name>
+    </property>
+    <property>
+      <parameters>title=$services.localization.render('phenotips.UIXField.globalModeOfInheritance')
+enabled=true
+required=
+order=15
+fields=global_mode_of_inheritance</parameters>
+    </property>
+    <property>
+      <scope>wiki</scope>
+    </property>
+  </object>
+</xwikidoc>

--- a/ui/src/main/resources/PhenoTips/UIX_Field__global_mode_of_inheritance.xml
+++ b/ui/src/main/resources/PhenoTips/UIX_Field__global_mode_of_inheritance.xml
@@ -115,7 +115,7 @@
 {{/velocity}}</content>
     </property>
     <property>
-      <extensionPointId>org.phenotips.patientSheet.section.family-info</extensionPointId>
+      <extensionPointId>org.phenotips.patientSheet.section.patient-info</extensionPointId>
     </property>
     <property>
       <name>org.phenotips.patientSheet.field.global_mode_of_inheritance</name>
@@ -124,7 +124,7 @@
       <parameters>title=$services.localization.render('phenotips.UIXField.globalModeOfInheritance')
 enabled=true
 required=
-order=15
+order=11
 fields=global_mode_of_inheritance</parameters>
     </property>
     <property>


### PR DESCRIPTION
- Removes family history consent requirement for age of onset and mode of inheritance fields
- Overwrites PhenoTips UIX fields for age of onset and mode of inheritance in order to change extension point and move under patient information.