### PR TITLE
 PC-217: Sharing with MME should be on by default in the consents

### DIFF
--- a/ui/src/main/resources/PhenoTips/PatientTemplate.xml
+++ b/ui/src/main/resources/PhenoTips/PatientTemplate.xml
@@ -1334,7 +1334,9 @@
       </granted>
     </class>
     <property>
-      <granted/>
+      <granted>
+        <value>matching</value>
+      </granted>
     </property>
   </object>
   <object>


### PR DESCRIPTION
Quick fix: List the default consents in patient template.